### PR TITLE
remove aws-auth configmap entries when appropriate

### DIFF
--- a/cmd/aws2k8s/main.go
+++ b/cmd/aws2k8s/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
-	"go.dfds.cloud/aad-aws-sync/internal/handler"
 	"log"
+
+	"go.dfds.cloud/aad-aws-sync/internal/handler"
+	"go.dfds.cloud/aad-aws-sync/internal/util"
 )
 
 func main() {
+	util.InitializeLogger()
 	err := handler.Aws2K8sHandler(context.TODO())
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Very rough WIP of removing aws-auth configmap entries when permission sets no longer exist in AWS SSO. To be improved later