### PR TITLE
feat/add event functionality to orchestrator

### DIFF
--- a/cmd/event/main.go
+++ b/cmd/event/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"go.dfds.cloud/aad-aws-sync/internal/config"
+	"go.dfds.cloud/aad-aws-sync/internal/event"
+	"go.dfds.cloud/aad-aws-sync/internal/util"
+	"go.uber.org/zap"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	util.InitializeLogger()
+	conf, err := config.LoadConfig()
+	if err != nil {
+		util.Logger.Fatal("Unable to load config", zap.Error(err))
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	err = event.StartEventHandlers(ctx, conf)
+	if err != nil {
+		util.Logger.Fatal("", zap.Error(err))
+	}
+}

--- a/cmd/handlers/main.go
+++ b/cmd/handlers/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"go.dfds.cloud/aad-aws-sync/internal/event_handlers"
 	"os"
 	"os/signal"
 	"sync"
@@ -87,7 +88,7 @@ func main() {
 	}
 
 	// Iniate the dialer
-	dialer := kafkautil.NewDialer(authConfig)
+	dialer, _ := kafkautil.NewDialer(authConfig)
 
 	// Initiate consumer
 	consumer := kafkautil.NewConsumer(consumerConfig, authConfig, dialer)

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -187,7 +187,7 @@ func main() {
 	// Event handling
 	if conf.EventHandling.Enabled {
 		go func() {
-			err = event.StartEventHandlers(ctx, conf)
+			err = event.StartEventHandlers(ctx, conf, backgroundJobWg)
 			if err != nil {
 				util.Logger.Error("Event loop error, shutting down.", zap.Error(err))
 				stop()

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -185,12 +185,15 @@ func main() {
 	}()
 
 	// Event handling
-	go func() {
-		err = event.StartEventHandlers(ctx, conf)
-		if err != nil {
-			stop()
-		}
-	}()
+	if conf.EventHandling.Enabled {
+		go func() {
+			err = event.StartEventHandlers(ctx, conf)
+			if err != nil {
+				util.Logger.Error("Event loop error, shutting down.", zap.Error(err))
+				stop()
+			}
+		}()
+	}
 
 	// Profiling endpoint
 	go func() {

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -40,7 +40,7 @@ type ScimClient struct {
 	http     *http.Client
 }
 
-func NewScimClient(endpoint string, token string) *ScimClient {
+func CreateScimClient(endpoint string, token string) *ScimClient {
 	sc := &ScimClient{
 		token:    token,
 		endpoint: endpoint,
@@ -293,7 +293,7 @@ func (c *ScimClient) PatchAddMembersToGroup(groupId string, members ...string) e
 	return nil
 }
 
-func (c *ScimClient) PatchRemoveMembersToGroup(groupId string, members ...string) error {
+func (c *ScimClient) PatchRemoveMembersFromGroup(groupId string, members ...string) error {
 	reqPatch := NewScimPatchRemoveMembersToGroupRequest(members...)
 	reqPayload, err := json.Marshal(reqPatch)
 	if err != nil {

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -1,7 +1,10 @@
 package aws
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	awsHttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -17,6 +20,7 @@ import (
 	"go.dfds.cloud/aad-aws-sync/internal/util"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -28,6 +32,137 @@ type SsoRoleMapping struct {
 	RoleName     string
 	RoleArn      string
 	RootId       string
+}
+
+type ScimClient struct {
+	token    string
+	endpoint string
+	http     *http.Client
+}
+
+func NewScimClient(endpoint string, token string) *ScimClient {
+	sc := &ScimClient{
+		token:    token,
+		endpoint: endpoint,
+	}
+	httpClient := http.DefaultClient
+	sc.http = httpClient
+
+	return sc
+}
+
+func (c *ScimClient) prepareHttpRequest(h *http.Request) error {
+	h.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	h.Header.Set("User-Agent", "aad-aws-sync - github.com/dfds/aad-aws-sync")
+
+	return nil
+}
+
+func (c *ScimClient) GetUserViaExternalId(id string) (*ScimGetUserResponse, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/scim/v2/Users", c.endpoint), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	urlQueryValues := req.URL.Query()
+	urlQueryValues.Set("filter", fmt.Sprintf("externalId eq \"%s\"", id))
+	req.URL.RawQuery = urlQueryValues.Encode()
+
+	err = c.prepareHttpRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	rawData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload *ScimGetUsersResponse
+
+	err = json.Unmarshal(rawData, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	if payload.TotalResults == 1 {
+		return payload.Resources[0], nil
+	}
+
+	return nil, errors.New("response didn't return 1 exact match")
+}
+
+func (c *ScimClient) PatchAddMembersToGroup(groupId string, members ...string) error {
+	reqPatch := NewScimPatchAddMembersToGroupRequest(members...)
+	reqPayload, err := json.Marshal(reqPatch)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/scim/v2/Groups/%s", c.endpoint, groupId), bytes.NewBuffer(reqPayload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	err = c.prepareHttpRequest(req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return errors.New(fmt.Sprintf("Received unexpected status code response, %d", resp.StatusCode))
+	}
+
+	return nil
+}
+
+func (c *ScimClient) PatchRemoveMembersToGroup(groupId string, members ...string) error {
+	reqPatch := NewScimPatchRemoveMembersToGroupRequest(members...)
+	reqPayload, err := json.Marshal(reqPatch)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/scim/v2/Groups/%s", c.endpoint, groupId), bytes.NewBuffer(reqPayload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	err = c.prepareHttpRequest(req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return errors.New(fmt.Sprintf("Received unexpected status code response, %d", resp.StatusCode))
+	}
+
+	return nil
 }
 
 func GetAccounts(client *organizations.Client) ([]orgTypes.Account, error) {

--- a/internal/aws/model.go
+++ b/internal/aws/model.go
@@ -70,6 +70,43 @@ type ScimGetUserResponse struct {
 	} `json:"urn:ietf:params:scim:schemas:extension:enterprise:2.1:User"`
 }
 
+type ScimGetGroupsResponse struct {
+	TotalResults int                     `json:"totalResults"`
+	ItemsPerPage int                     `json:"itemsPerPage"`
+	StartIndex   int                     `json:"startIndex"`
+	Schemas      []string                `json:"schemas"`
+	Resources    []*ScimGetGroupResponse `json:"Resources"`
+}
+
+type ScimCreateGroupRequest struct {
+	DisplayName string `json:"displayName"`
+	Externalid  string `json:"externalid"`
+}
+
+type ScimCreateUserRequest struct {
+	UserName    string `json:"userName"`
+	ExternalID  string `json:"externalId"`
+	DisplayName string `json:"displayName"`
+	Active      bool   `json:"active"`
+	Name        struct {
+		GivenName  string `json:"givenName"`
+		FamilyName string `json:"familyName"`
+	} `json:"name"`
+}
+
+type ScimGetGroupResponse struct {
+	ID         string `json:"id"`
+	ExternalID string `json:"externalId"`
+	Meta       struct {
+		ResourceType string    `json:"resourceType"`
+		Created      time.Time `json:"created"`
+		LastModified time.Time `json:"lastModified"`
+	} `json:"meta"`
+	Schemas     []string      `json:"schemas"`
+	DisplayName string        `json:"displayName"`
+	Members     []interface{} `json:"members"`
+}
+
 type ScimPatchMembersToGroupRequest struct {
 	Schemas    []string                                  `json:"schemas"`
 	Operations []ScimPatchMembersToGroupOperationRequest `json:"Operations"`

--- a/internal/aws/model.go
+++ b/internal/aws/model.go
@@ -3,6 +3,7 @@ package aws
 import (
 	identityStoreTypes "github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	orgTypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"time"
 )
 
 type CapabilitySso struct {
@@ -19,4 +20,105 @@ type GetAccountsMissingCapabilityPermissionSetResponse struct {
 type GetGroupsNotAssignedToAccountWithPermissionSetResponse struct {
 	GroupsNotAssigned []*identityStoreTypes.Group
 	GroupsAssigned    []*identityStoreTypes.Group
+}
+
+type ScimGetUsersResponse struct {
+	TotalResults int                    `json:"totalResults"`
+	ItemsPerPage int                    `json:"itemsPerPage"`
+	StartIndex   int                    `json:"startIndex"`
+	Schemas      []string               `json:"schemas"`
+	Resources    []*ScimGetUserResponse `json:"Resources"`
+}
+
+type ScimGetUserResponse struct {
+	ID         string `json:"id"`
+	ExternalID string `json:"externalId"`
+	Meta       struct {
+		ResourceType string    `json:"resourceType"`
+		Created      time.Time `json:"created"`
+		LastModified time.Time `json:"lastModified"`
+	} `json:"meta"`
+	Schemas  []string `json:"schemas"`
+	UserName string   `json:"userName"`
+	Name     struct {
+		Formatted  string `json:"formatted"`
+		FamilyName string `json:"familyName"`
+		GivenName  string `json:"givenName"`
+	} `json:"name"`
+	DisplayName string `json:"displayName"`
+	Title       string `json:"title"`
+	Active      bool   `json:"active"`
+	Emails      []struct {
+		Value   string `json:"value"`
+		Type    string `json:"type"`
+		Primary bool   `json:"primary"`
+	} `json:"emails"`
+	Addresses []struct {
+		StreetAddress string `json:"streetAddress"`
+		Locality      string `json:"locality"`
+		PostalCode    string `json:"postalCode"`
+		Country       string `json:"country"`
+		Type          string `json:"type"`
+		Primary       bool   `json:"primary"`
+	} `json:"addresses"`
+	UrnIetfParamsScimSchemasExtensionEnterprise21User struct {
+		EmployeeNumber string `json:"employeeNumber"`
+		Department     string `json:"department"`
+		Manager        struct {
+			Value string `json:"value"`
+		} `json:"manager"`
+	} `json:"urn:ietf:params:scim:schemas:extension:enterprise:2.1:User"`
+}
+
+type ScimPatchMembersToGroupRequest struct {
+	Schemas    []string                                  `json:"schemas"`
+	Operations []ScimPatchMembersToGroupOperationRequest `json:"Operations"`
+}
+
+type ScimPatchMembersToGroupOperationRequest struct {
+	Op    string                                         `json:"op"`
+	Path  string                                         `json:"path"`
+	Value []ScimPatchMembersToGroupOperationValueRequest `json:"value"`
+}
+
+type ScimPatchMembersToGroupOperationValueRequest struct {
+	Value string `json:"value"`
+}
+
+func NewScimPatchAddMembersToGroupRequest(members ...string) ScimPatchMembersToGroupRequest {
+	payload := ScimPatchMembersToGroupRequest{
+		Schemas: []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		Operations: []ScimPatchMembersToGroupOperationRequest{
+			{
+				Op:    "add",
+				Path:  "members",
+				Value: []ScimPatchMembersToGroupOperationValueRequest{},
+			},
+		},
+	}
+
+	for _, member := range members {
+		payload.Operations[0].Value = append(payload.Operations[0].Value, ScimPatchMembersToGroupOperationValueRequest{Value: member})
+	}
+
+	return payload
+}
+
+func NewScimPatchRemoveMembersToGroupRequest(members ...string) ScimPatchMembersToGroupRequest {
+	payload := ScimPatchMembersToGroupRequest{
+		Schemas: []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		Operations: []ScimPatchMembersToGroupOperationRequest{
+			{
+				Op:    "remove",
+				Path:  "members",
+				Value: []ScimPatchMembersToGroupOperationValueRequest{},
+			},
+		},
+	}
+
+	for _, member := range members {
+		payload.Operations[0].Value = append(payload.Operations[0].Value, ScimPatchMembersToGroupOperationValueRequest{Value: member})
+	}
+
+	return payload
 }

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -417,6 +417,38 @@ func (c *Client) GetAdministrativeUnitMembers(id string) (*GetAdministrativeUnit
 	return payload, nil
 }
 
+func (c *Client) GetUserViaUPN(upn string) (*GetUserViaUPNResponse, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://graph.microsoft.com/v1.0/users/%s", upn), nil)
+	if err != nil {
+		return nil, err
+	}
+	err = c.prepareHttpRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	rawData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload *GetUserViaUPNResponse
+
+	err = json.Unmarshal(rawData, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
 func (c *Client) GetGroupMembers(id string) (*GroupMembers, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://graph.microsoft.com/v1.0/groups/%s/members", id), nil)
 	if err != nil {

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -309,6 +309,11 @@ func (c *Client) AddGroupMember(groupId string, upn string) error {
 			return HttpError403.New("Response returned with unexpected 403. Skipping entry")
 		}
 
+		if resp.StatusCode == 400 {
+			util.Logger.Info("Response returned with unexpected 400. User might already be a member.")
+			return nil
+		}
+
 		return HttpError.New(fmt.Sprintf("Unexpected HTTP response. Status code: %d", resp.StatusCode))
 	}
 

--- a/internal/azure/model.go
+++ b/internal/azure/model.go
@@ -84,6 +84,21 @@ type AddGroupMemberRequest struct {
 	OdataId string `json:"@odata.id"`
 }
 
+type GetUserViaUPNResponse struct {
+	OdataContext      string        `json:"@odata.context"`
+	BusinessPhones    []interface{} `json:"businessPhones"`
+	DisplayName       string        `json:"displayName"`
+	GivenName         string        `json:"givenName"`
+	JobTitle          string        `json:"jobTitle"`
+	Mail              string        `json:"mail"`
+	MobilePhone       interface{}   `json:"mobilePhone"`
+	OfficeLocation    interface{}   `json:"officeLocation"`
+	PreferredLanguage interface{}   `json:"preferredLanguage"`
+	Surname           string        `json:"surname"`
+	UserPrincipalName string        `json:"userPrincipalName"`
+	ID                string        `json:"id"`
+}
+
 type CreateAdministrativeUnitGroupResponse struct {
 	OdataContext                  string        `json:"@odata.context"`
 	OdataType                     string        `json:"@odata.type"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,9 @@ type Config struct {
 		Level string `json:"level"`
 		Debug bool   `json:"debug"`
 	}
+	EventHandling struct {
+		Enabled bool `json:"enable"`
+	}
 	Scheduler struct {
 		Frequency          string `json:"scheduleFrequency" default:"30m"`
 		EnableCapsvc2Azure bool   `json:"enableCapsvc2Azure"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,10 @@ type Config struct {
 			SsoManagementArn          string `json:"ssoManagementArn"`
 			CapabilityAccountRoleName string `json:"capabilityAccountRoleName"`
 		} `json:"assumableRoles"`
+		Scim struct {
+			Endpoint string `json:"endpoint"`
+			Token    string `json:"token"`
+		}
 	} `json:"aws"`
 	Azure struct {
 		TenantId            string `json:"tenantId"`

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -66,7 +66,7 @@ func StartEventHandlers(ctx context.Context, conf config.Config, wg *sync.WaitGr
 	}
 
 	registry := NewRegistry()
-	registry.Register("capability_created", handlers.CapabilityCreatedHandler)
+	//registry.Register("capability_created", handlers.CapabilityCreatedHandler)
 	registry.Register("member_joined_capability", handlers.MemberJoinedCapabilityHandler)
 	registry.Register("member_left_capability", handlers.MemberLeftCapabilityHandler)
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -1,0 +1,153 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/segmentio/kafka-go"
+	"go.dfds.cloud/aad-aws-sync/internal/config"
+	"go.dfds.cloud/aad-aws-sync/internal/event/handlers"
+	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+	"go.dfds.cloud/aad-aws-sync/internal/kafkautil"
+	"go.dfds.cloud/aad-aws-sync/internal/util"
+	"go.uber.org/zap"
+	"io"
+	"sync"
+)
+
+func GetEventFromMsg(data []byte) (*model.Envelope, error) {
+	var payload *model.Envelope
+	err := json.Unmarshal(data, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
+func commitMsg(ctx context.Context, msg kafka.Message, consumer *kafka.Reader) error {
+	err := consumer.CommitMessages(ctx, msg)
+	if err != nil {
+		return err
+	}
+
+	msgLog := util.Logger.With(zap.String("topic", msg.Topic),
+		zap.Int("partition", msg.Partition),
+		zap.Int64("offset", msg.Offset))
+	msgLog.Debug("Commit for consumer group updated")
+
+	return nil
+}
+
+func StartEventHandlers(ctx context.Context, conf config.Config) error {
+	var authConfig kafkautil.AuthConfig
+	err := envconfig.Process("AAS_KAFKA_AUTH", &authConfig)
+	if err != nil {
+		return err
+	}
+
+	var consumerConfig kafkautil.ConsumerConfig
+	err = envconfig.Process("AAS_KAFKA_CONSUMER", &consumerConfig)
+	if err != nil {
+		return errors.New("failed to process consumer configurations")
+	}
+
+	var producerConfig kafkautil.ProducerConfig
+	err = envconfig.Process("AAS_KAFKA_PRODUCER", &producerConfig)
+	if err != nil {
+		return errors.New("failed to process producer configurations")
+	}
+
+	var errorProducerConfig kafkautil.ProducerConfig
+	err = envconfig.Process("AAS_KAFKA_ERROR_PRODUCER", &errorProducerConfig)
+	if err != nil {
+		return errors.New("failed to process error producer configurations")
+	}
+
+	registry := NewRegistry()
+	registry.Register("capability_created", handlers.CapabilityCreatedHandler)
+
+	dialer, err := kafkautil.NewDialer(authConfig)
+	if err != nil {
+		return err
+	}
+
+	consumer := kafkautil.NewConsumer(consumerConfig, authConfig, dialer)
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		util.Logger.Debug("Closing Kafka consumer")
+		if err := consumer.Close(); err != nil {
+			util.Logger.Fatal("Failed to close Kafka consumer", zap.Error(err))
+		}
+		util.Logger.Debug("Kafka consumer has been closed")
+	}
+	defer cleanupOnce.Do(cleanup)
+
+	for {
+		util.Logger.Debug("Awaiting new message from topic")
+		msg, err := consumer.FetchMessage(ctx)
+		if err == io.EOF {
+			util.Logger.Info("Connection closed")
+			break
+		} else if err == context.Canceled {
+			util.Logger.Info("Processing canceled")
+			break
+		} else if err != nil {
+			util.Logger.Error("Error fetching message", zap.Error(err))
+			break
+		}
+		msgLog := util.Logger.With(zap.String("topic", msg.Topic),
+			zap.Int("partition", msg.Partition),
+			zap.Int64("offset", msg.Offset),
+			zap.String("key", string(msg.Key)),
+			zap.String("value", string(msg.Value)))
+		msgLog.Debug("Message fetched")
+
+		// Convert msg to Event
+		var handler HandlerFunc
+		var eventLog *zap.Logger
+
+		event, err := GetEventFromMsg(msg.Value)
+		if err != nil {
+			msgLog.Info("Unable to deserialise message payload. Quite likely the message is not valid JSON. Skipping message")
+			goto CommitOffset
+		}
+
+		if event == nil || event.Name == "" {
+			msgLog.Info("Unable to recognise event envelope, skipping message")
+			goto CommitOffset
+		}
+
+		eventLog = util.Logger.With(zap.String("topic", msg.Topic),
+			zap.Int("partition", msg.Partition),
+			zap.Int64("offset", msg.Offset),
+			zap.String("key", string(msg.Key)),
+			zap.String("eventName", event.Name))
+
+		handler = registry.GetHandler(event.Name)
+		if handler == nil {
+			eventLog.Info("No handler registered for event, skipping.")
+			goto CommitOffset
+		}
+
+		err = handler(ctx, model.HandlerContext{
+			Event: event,
+			Msg:   msg.Value,
+		})
+		if err != nil {
+			eventLog.Error("Handler for event failed", zap.Error(err))
+			break // TODO: Trigger graceful shutdown
+		}
+
+	CommitOffset:
+		err = commitMsg(ctx, msg, consumer)
+		if err != nil {
+			msgLog.Error("Unable to update commit for consumer group") // TODO: Trigger graceful shutdown
+		}
+	}
+
+	cleanupOnce.Do(cleanup)
+
+	return nil
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -40,7 +40,7 @@ func commitMsg(ctx context.Context, msg kafka.Message, consumer *kafka.Reader) e
 	return nil
 }
 
-func StartEventHandlers(ctx context.Context, conf config.Config) error {
+func StartEventHandlers(ctx context.Context, conf config.Config, wg *sync.WaitGroup) error {
 	var authConfig kafkautil.AuthConfig
 	err := envconfig.Process("AAS_KAFKA_AUTH", &authConfig)
 	if err != nil {
@@ -88,6 +88,8 @@ func StartEventHandlers(ctx context.Context, conf config.Config) error {
 
 	dlqProducer := kafkautil.NewProducer(errorProducerConfig, authConfig, dialer)
 
+	wg.Add(1)
+	defer wg.Done()
 	for {
 		util.Logger.Debug("Awaiting new message from topic")
 		msg, err := consumer.FetchMessage(ctx)

--- a/internal/event/handlers/capability_created.go
+++ b/internal/event/handlers/capability_created.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+	"go.dfds.cloud/aad-aws-sync/internal/util"
+	"go.uber.org/zap"
+)
+
+type capabilityCreated struct {
+	CapabilityID   string `json:"capabilityId"`
+	CapabilityName string `json:"capabilityName"`
+}
+
+func CapabilityCreatedHandler(ctx context.Context, event model.HandlerContext) error {
+	util.Logger.Info("New Capability discovered. Creating entries in AAD")
+	msg, err := GetEventWithPayloadFromMsg[capabilityCreated](event.Msg)
+	if err != nil {
+		return err
+	}
+
+	util.Logger.Info("Payload", zap.Any("payload", msg))
+
+	return errors.New("triggering error on purpose")
+}

--- a/internal/event/handlers/capability_created.go
+++ b/internal/event/handlers/capability_created.go
@@ -3,7 +3,12 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"go.dfds.cloud/aad-aws-sync/internal/azure"
+	"go.dfds.cloud/aad-aws-sync/internal/capsvc"
+	"go.dfds.cloud/aad-aws-sync/internal/config"
 	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+	"go.dfds.cloud/aad-aws-sync/internal/handler"
 	"go.dfds.cloud/aad-aws-sync/internal/util"
 	"go.uber.org/zap"
 )
@@ -14,13 +19,138 @@ type capabilityCreated struct {
 }
 
 func CapabilityCreatedHandler(ctx context.Context, event model.HandlerContext) error {
-	util.Logger.Info("New Capability discovered. Creating entries in AAD")
+	msgLog := util.Logger.With(zap.String("event_handler", "CapabilityCreatedHandler"), zap.String("event", event.Event.Name))
+	msgLog.Info("New Capability discovered. Creating entries in AAD")
 	msg, err := GetEventWithPayloadFromMsg[capabilityCreated](event.Msg)
 	if err != nil {
 		return err
 	}
+	msgLog = msgLog.With(zap.String("capabilityId", msg.Payload.CapabilityID))
 
-	util.Logger.Info("Payload", zap.Any("payload", msg))
+	var capability *capsvc.GetCapabilitiesResponseContextCapability
 
-	return errors.New("triggering error on purpose")
+	conf, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	groupsInAzure := make(map[string]*azure.Group)
+	client := capsvc.NewCapSvcClient(capsvc.Config{
+		Host:         conf.CapSvc.Host,
+		TenantId:     conf.Azure.TenantId,
+		ClientId:     conf.Azure.ClientId,
+		ClientSecret: conf.Azure.ClientSecret,
+		Scope:        conf.CapSvc.TokenScope,
+	})
+
+	capabilities, err := client.GetCapabilities()
+	if err != nil {
+		return err
+	}
+
+	for _, capa := range capabilities.Items {
+		if capa.ID == msg.Payload.CapabilityID {
+			capability = capa
+			break
+		}
+	}
+
+	if capability == nil {
+		return errors.New("capability from event not found in Capability-Service")
+	}
+	msgLog = msgLog.With(zap.String("capabilityRootId", capability.RootID))
+
+	azureClient := azure.NewAzureClient(azure.Config{
+		TenantId:     conf.Azure.TenantId,
+		ClientId:     conf.Azure.ClientId,
+		ClientSecret: conf.Azure.ClientSecret,
+	})
+
+	aUnits, err := azureClient.GetAdministrativeUnits()
+	if err != nil {
+		return err
+	}
+
+	aUnit := aUnits.GetUnit("Team - Cloud Engineering - Self service")
+	if aUnit == nil {
+		return errors.New("unable to find administrative unit")
+	}
+
+	aUnitMembers, err := azureClient.GetAdministrativeUnitMembers(aUnit.ID)
+	if err != nil {
+		return err
+	}
+
+	for _, member := range aUnitMembers.Value {
+		select {
+		case <-ctx.Done():
+			msgLog.Info("Job cancelled")
+			return errors.New("event handling cancelled via context")
+		default:
+			group := &azure.Group{
+				DisplayName: member.DisplayName,
+				ID:          member.ID,
+				Members:     []*azure.Member{},
+			}
+			groupsInAzure[group.DisplayName] = group
+		}
+	}
+
+	azureGroupName := fmt.Sprintf("%s %s", handler.CAPABILITY_GROUP_PREFIX, capability.RootID)
+	var azureGroup *azure.Group
+	// Check if Capability has a group in Azure AD, if it doesn't create it
+	if resp, ok := groupsInAzure[azureGroupName]; !ok {
+		msgLog.Info(fmt.Sprintf("Capability %s doesn't exist in Azure, creating.", capability.RootID))
+		createGroupRequest := azure.CreateAdministrativeUnitGroupRequest{
+			OdataType:       "#Microsoft.Graph.Group",
+			Description:     "[Automated] - aad-aws-sync",
+			DisplayName:     azure.GenerateAzureGroupDisplayName(capability.RootID),
+			MailNickname:    azure.GenerateAzureGroupMailPrefix(capability.RootID),
+			GroupTypes:      []interface{}{},
+			MailEnabled:     false,
+			SecurityEnabled: true,
+
+			ParentAdministrativeUnitId: aUnit.ID,
+		}
+		resp, err := azureClient.CreateAdministrativeUnitGroup(ctx, createGroupRequest)
+		if err != nil {
+			return err
+		}
+
+		azureGroup = &azure.Group{ID: resp.ID, DisplayName: resp.DisplayName}
+	} else {
+		azureGroup = resp
+	}
+
+	select {
+	case <-ctx.Done():
+		msgLog.Info("Job cancelled")
+		return errors.New("event handling cancelled via context")
+	default:
+	}
+
+	appRoles, err := azureClient.GetApplicationRoles(conf.Azure.ApplicationId)
+	if err != nil {
+		return err
+	}
+
+	appRoleId, err := appRoles.GetRoleId("User")
+	if err != nil {
+		return err
+	}
+
+	appAssignments, err := azureClient.GetAssignmentsForApplication(conf.Azure.ApplicationObjectId)
+	if err != nil {
+		return err
+	}
+
+	if !appAssignments.ContainsGroup(azureGroup.DisplayName) {
+		msgLog.Info(fmt.Sprintf("Group %s has not been assigned to application yet, assigning", azureGroup.DisplayName))
+		_, err := azureClient.AssignGroupToApplication(conf.Azure.ApplicationObjectId, azureGroup.ID, appRoleId)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/event/handlers/handler.go
+++ b/internal/event/handlers/handler.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	"encoding/json"
+	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+)
+
+func GetEventWithPayloadFromMsg[T any](data []byte) (*model.EnvelopeWithPayload[T], error) {
+	var payload *model.EnvelopeWithPayload[T]
+	err := json.Unmarshal(data, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}

--- a/internal/event/handlers/member_joined_capability.go
+++ b/internal/event/handlers/member_joined_capability.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go.dfds.cloud/aad-aws-sync/internal/azure"
+	"go.dfds.cloud/aad-aws-sync/internal/capsvc"
+	"go.dfds.cloud/aad-aws-sync/internal/config"
+	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+	"go.dfds.cloud/aad-aws-sync/internal/handler"
+	"go.dfds.cloud/aad-aws-sync/internal/util"
+	"go.uber.org/zap"
+)
+
+type memberJoinedCapability struct {
+	CapabilityId string `json:"capabilityId"`
+	MemberEmail  string `json:"memberEmail"`
+}
+
+func MemberJoinedCapabilityHandler(ctx context.Context, event model.HandlerContext) error {
+	msgLog := util.Logger.With(zap.String("event_handler", "MemberJoinedCapabilityHandler"), zap.String("event", event.Event.Name))
+	msg, err := GetEventWithPayloadFromMsg[memberJoinedCapability](event.Msg)
+	if err != nil {
+		return err
+	}
+	msgLog = msgLog.With(zap.String("capabilityId", msg.Payload.CapabilityId))
+
+	var capability *capsvc.GetCapabilitiesResponseContextCapability
+
+	conf, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	groupsInAzure := make(map[string]*azure.Group)
+	capSvcClient := capsvc.NewCapSvcClient(capsvc.Config{
+		Host:         conf.CapSvc.Host,
+		TenantId:     conf.Azure.TenantId,
+		ClientId:     conf.Azure.ClientId,
+		ClientSecret: conf.Azure.ClientSecret,
+		Scope:        conf.CapSvc.TokenScope,
+	})
+
+	azureClient := azure.NewAzureClient(azure.Config{
+		TenantId:     conf.Azure.TenantId,
+		ClientId:     conf.Azure.ClientId,
+		ClientSecret: conf.Azure.ClientSecret,
+	})
+
+	capabilities, err := capSvcClient.GetCapabilities()
+	if err != nil {
+		return err
+	}
+
+	for _, capa := range capabilities.Items {
+		if capa.ID == msg.Payload.CapabilityId {
+			capability = capa
+			break
+		}
+	}
+
+	if capability == nil {
+		return errors.New("capability from event not found in Capability-Service")
+	}
+	msgLog = msgLog.With(zap.String("capabilityRootId", capability.RootID))
+	msgLog.Info(fmt.Sprintf("%s joined Capability %s. Updating AAD group", msg.Payload.MemberEmail, capability.RootID))
+
+	aUnits, err := azureClient.GetAdministrativeUnits()
+	if err != nil {
+		return err
+	}
+
+	aUnit := aUnits.GetUnit("Team - Cloud Engineering - Self service")
+	if aUnit == nil {
+		return errors.New("unable to find administrative unit")
+	}
+
+	aUnitMembers, err := azureClient.GetAdministrativeUnitMembers(aUnit.ID)
+	if err != nil {
+		return err
+	}
+
+	for _, member := range aUnitMembers.Value {
+		select {
+		case <-ctx.Done():
+			msgLog.Info("Job cancelled")
+			return errors.New("event handling cancelled via context")
+		default:
+			group := &azure.Group{
+				DisplayName: member.DisplayName,
+				ID:          member.ID,
+				Members:     []*azure.Member{},
+			}
+			groupsInAzure[group.DisplayName] = group
+		}
+	}
+
+	azureGroupName := fmt.Sprintf("%s %s", handler.CAPABILITY_GROUP_PREFIX, capability.RootID)
+	var azureGroup *azure.Group
+	if resp, ok := groupsInAzure[azureGroupName]; !ok {
+		return errors.New(fmt.Sprintf("Capability %s doesn't exist in Azure. Unable to add new member", capability.RootID))
+	} else {
+		azureGroup = resp
+	}
+
+	err = azureClient.AddGroupMember(azureGroup.ID, msg.Payload.MemberEmail)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/event/handlers/member_left_capability.go
+++ b/internal/event/handlers/member_left_capability.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go.dfds.cloud/aad-aws-sync/internal/azure"
+	"go.dfds.cloud/aad-aws-sync/internal/capsvc"
+	"go.dfds.cloud/aad-aws-sync/internal/config"
+	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+	"go.dfds.cloud/aad-aws-sync/internal/handler"
+	"go.dfds.cloud/aad-aws-sync/internal/util"
+	"go.uber.org/zap"
+)
+
+type memberLeftCapability struct {
+	CapabilityId string `json:"capabilityId"`
+	MemberEmail  string `json:"memberEmail"`
+}
+
+func MemberLeftCapabilityHandler(ctx context.Context, event model.HandlerContext) error {
+	msgLog := util.Logger.With(zap.String("event_handler", "MemberLeftCapabilityHandler"), zap.String("event", event.Event.Name))
+	msg, err := GetEventWithPayloadFromMsg[memberLeftCapability](event.Msg)
+	if err != nil {
+		return err
+	}
+	msgLog = msgLog.With(zap.String("capabilityId", msg.Payload.CapabilityId))
+
+	var capability *capsvc.GetCapabilitiesResponseContextCapability
+
+	conf, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	groupsInAzure := make(map[string]*azure.Group)
+	capSvcClient := capsvc.NewCapSvcClient(capsvc.Config{
+		Host:         conf.CapSvc.Host,
+		TenantId:     conf.Azure.TenantId,
+		ClientId:     conf.Azure.ClientId,
+		ClientSecret: conf.Azure.ClientSecret,
+		Scope:        conf.CapSvc.TokenScope,
+	})
+
+	azureClient := azure.NewAzureClient(azure.Config{
+		TenantId:     conf.Azure.TenantId,
+		ClientId:     conf.Azure.ClientId,
+		ClientSecret: conf.Azure.ClientSecret,
+	})
+
+	capabilities, err := capSvcClient.GetCapabilities()
+	if err != nil {
+		return err
+	}
+
+	for _, capa := range capabilities.Items {
+		if capa.ID == msg.Payload.CapabilityId {
+			capability = capa
+			break
+		}
+	}
+
+	if capability == nil {
+		return errors.New("capability from event not found in Capability-Service")
+	}
+	msgLog = msgLog.With(zap.String("capabilityRootId", capability.RootID))
+	msgLog.Info(fmt.Sprintf("%s left Capability %s. Updating AAD group", msg.Payload.MemberEmail, capability.RootID))
+
+	aUnits, err := azureClient.GetAdministrativeUnits()
+	if err != nil {
+		return err
+	}
+
+	aUnit := aUnits.GetUnit("Team - Cloud Engineering - Self service")
+	if aUnit == nil {
+		return errors.New("unable to find administrative unit")
+	}
+
+	aUnitMembers, err := azureClient.GetAdministrativeUnitMembers(aUnit.ID)
+	if err != nil {
+		return err
+	}
+
+	for _, member := range aUnitMembers.Value {
+		select {
+		case <-ctx.Done():
+			msgLog.Info("Job cancelled")
+			return errors.New("event handling cancelled via context")
+		default:
+			group := &azure.Group{
+				DisplayName: member.DisplayName,
+				ID:          member.ID,
+				Members:     []*azure.Member{},
+			}
+			groupsInAzure[group.DisplayName] = group
+		}
+	}
+
+	azureGroupName := fmt.Sprintf("%s %s", handler.CAPABILITY_GROUP_PREFIX, capability.RootID)
+	var azureGroup *azure.Group
+	if resp, ok := groupsInAzure[azureGroupName]; !ok {
+		return errors.New(fmt.Sprintf("Capability %s doesn't exist in Azure. Unable to add new member", capability.RootID))
+	} else {
+		azureGroup = resp
+	}
+
+	aadUser, err := azureClient.GetUserViaUPN(msg.Payload.MemberEmail)
+	if err != nil {
+		return err
+	}
+	err = azureClient.DeleteGroupMember(azureGroup.ID, aadUser.ID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/event/model/event.go
+++ b/internal/event/model/event.go
@@ -1,0 +1,17 @@
+package model
+
+type Envelope struct {
+	Name    string `json:"eventName"`
+	Version string `json:"version"`
+}
+
+type EnvelopeWithPayload[T any] struct {
+	Name    string `json:"eventName"`
+	Version string `json:"version"`
+	Payload T      `json:"payload"`
+}
+
+type HandlerContext struct {
+	Event *Envelope
+	Msg   []byte
+}

--- a/internal/event/registry.go
+++ b/internal/event/registry.go
@@ -1,0 +1,26 @@
+package event
+
+import (
+	"context"
+	"go.dfds.cloud/aad-aws-sync/internal/event/model"
+)
+
+type HandlerFunc func(ctx context.Context, event model.HandlerContext) error
+
+type Registry struct {
+	handlers map[string]HandlerFunc
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		handlers: map[string]HandlerFunc{},
+	}
+}
+
+func (r *Registry) Register(eventName string, f HandlerFunc) {
+	r.handlers[eventName] = f
+}
+
+func (r *Registry) GetHandler(eventName string) HandlerFunc {
+	return r.handlers[eventName]
+}

--- a/internal/kafkautil/config.go
+++ b/internal/kafkautil/config.go
@@ -16,7 +16,8 @@ type ProducerConfig struct {
 // AuthConfig allows one to configure auth with a plain SASL
 // authnetication mechanism to the Kafka brokers.
 type AuthConfig struct {
-	Brokers  []string `required:"true"`
-	Username string   `required:"true"`
-	Password string   `required:"true"`
+	Brokers          []string          `required:"true"`
+	Mechanism        string            `required:"true"`
+	MechanismOptions map[string]string `envconfig:"MECHANISM_OPTIONS"`
+	Tls              bool              `required:"true"`
 }

--- a/internal/kafkautil/config_test.go
+++ b/internal/kafkautil/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestConfigResolver(t *testing.T) {
-	var conf Config
+	var conf AuthConfig
 	err := envconfig.Process("AAS_KAFKA", &conf)
 	if err != nil {
 		log.Fatal("Failed to process auth configurations", zap.Error(err))

--- a/internal/kafkautil/dialer.go
+++ b/internal/kafkautil/dialer.go
@@ -55,5 +55,6 @@ func NewDialer(authConfig AuthConfig) (*kafka.Dialer, error) {
 		DualStack:     true,
 		TLS:           tlsConfig,
 		SASLMechanism: saslMechanism,
+		ClientID:      "aadawssync",
 	}, nil
 }


### PR DESCRIPTION
- Event loop can now register event handlers and use event handlers when a valid event is encountered
- Added DLQ for events that can't be successfully processed
- Added handler for capability_created, member_joined_capability, member_left_capability
- Added AWS SCIM client; Added support for adding and removing members from groups
- Expanded functionality of AWS SCIM client
- Event handlers for member_joined_capability and member_left capability now updates AWS objects


TODOs:

- Refactor code reuse in event handlers 