### PR TITLE
fix/update capsvc client

### DIFF
--- a/internal/capsvc/capsvc.go
+++ b/internal/capsvc/capsvc.go
@@ -38,8 +38,8 @@ func (c *Client) prepareHttpRequest(h *http.Request) error {
 	return nil
 }
 
-func (c *Client) GetCapabilities() (*GetCapabilitiesResponse, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/capabilities", c.config.Host), nil)
+func (c *Client) GetCapabilities() ([]*GetCapabilitiesResponseContextCapability, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/system/legacy/aad-aws-sync", c.config.Host), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (c *Client) GetCapabilities() (*GetCapabilitiesResponse, error) {
 		return nil, err
 	}
 
-	var payload *GetCapabilitiesResponse
+	var payload []*GetCapabilitiesResponseContextCapability
 
 	err = json.Unmarshal(rawData, &payload)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,8 +32,10 @@ type Config struct {
 		ApplicationObjectId string `json:"applicationObjectId"`
 	} `json:"azure"`
 	CapSvc struct { // Capability-Service
-		Host       string `json:"host"`
-		TokenScope string `json:"tokenScope"`
+		Host         string `json:"host"`
+		TokenScope   string `json:"tokenScope"`
+		ClientId     string `json:"clientId"`
+		ClientSecret string `json:"clientSecret"`
 	} `json:"capSvc"`
 	Log struct {
 		Level string `json:"level"`

--- a/internal/event/handlers/capability_created.go
+++ b/internal/event/handlers/capability_created.go
@@ -38,8 +38,8 @@ func CapabilityCreatedHandler(ctx context.Context, event model.HandlerContext) e
 	client := capsvc.NewCapSvcClient(capsvc.Config{
 		Host:         conf.CapSvc.Host,
 		TenantId:     conf.Azure.TenantId,
-		ClientId:     conf.Azure.ClientId,
-		ClientSecret: conf.Azure.ClientSecret,
+		ClientId:     conf.CapSvc.ClientId,
+		ClientSecret: conf.CapSvc.ClientSecret,
 		Scope:        conf.CapSvc.TokenScope,
 	})
 

--- a/internal/event/handlers/capability_created.go
+++ b/internal/event/handlers/capability_created.go
@@ -48,7 +48,7 @@ func CapabilityCreatedHandler(ctx context.Context, event model.HandlerContext) e
 		return err
 	}
 
-	for _, capa := range capabilities.Items {
+	for _, capa := range capabilities {
 		if capa.ID == msg.Payload.CapabilityID {
 			capability = capa
 			break

--- a/internal/event/handlers/member_joined_capability.go
+++ b/internal/event/handlers/member_joined_capability.go
@@ -38,8 +38,8 @@ func MemberJoinedCapabilityHandler(ctx context.Context, event model.HandlerConte
 	capSvcClient := capsvc.NewCapSvcClient(capsvc.Config{
 		Host:         conf.CapSvc.Host,
 		TenantId:     conf.Azure.TenantId,
-		ClientId:     conf.Azure.ClientId,
-		ClientSecret: conf.Azure.ClientSecret,
+		ClientId:     conf.CapSvc.ClientId,
+		ClientSecret: conf.CapSvc.ClientSecret,
 		Scope:        conf.CapSvc.TokenScope,
 	})
 

--- a/internal/event/handlers/member_joined_capability.go
+++ b/internal/event/handlers/member_joined_capability.go
@@ -56,7 +56,7 @@ func MemberJoinedCapabilityHandler(ctx context.Context, event model.HandlerConte
 		return err
 	}
 
-	for _, capa := range capabilities.Items {
+	for _, capa := range capabilities {
 		if capa.ID == msg.Payload.CapabilityId {
 			capability = capa
 			break

--- a/internal/event/handlers/member_left_capability.go
+++ b/internal/event/handlers/member_left_capability.go
@@ -38,8 +38,8 @@ func MemberLeftCapabilityHandler(ctx context.Context, event model.HandlerContext
 	capSvcClient := capsvc.NewCapSvcClient(capsvc.Config{
 		Host:         conf.CapSvc.Host,
 		TenantId:     conf.Azure.TenantId,
-		ClientId:     conf.Azure.ClientId,
-		ClientSecret: conf.Azure.ClientSecret,
+		ClientId:     conf.CapSvc.ClientId,
+		ClientSecret: conf.CapSvc.ClientSecret,
 		Scope:        conf.CapSvc.TokenScope,
 	})
 

--- a/internal/event/handlers/member_left_capability.go
+++ b/internal/event/handlers/member_left_capability.go
@@ -56,7 +56,7 @@ func MemberLeftCapabilityHandler(ctx context.Context, event model.HandlerContext
 		return err
 	}
 
-	for _, capa := range capabilities.Items {
+	for _, capa := range capabilities {
 		if capa.ID == msg.Payload.CapabilityId {
 			capability = capa
 			break

--- a/internal/handler/capsvc2aad.go
+++ b/internal/handler/capsvc2aad.go
@@ -27,8 +27,8 @@ func Capsvc2AadHandler(ctx context.Context) error {
 	client := capsvc.NewCapSvcClient(capsvc.Config{
 		Host:         conf.CapSvc.Host,
 		TenantId:     conf.Azure.TenantId,
-		ClientId:     conf.Azure.ClientId,
-		ClientSecret: conf.Azure.ClientSecret,
+		ClientId:     conf.CapSvc.ClientId,
+		ClientSecret: conf.CapSvc.ClientSecret,
 		Scope:        conf.CapSvc.TokenScope,
 	})
 

--- a/internal/handler/capsvc2aad.go
+++ b/internal/handler/capsvc2aad.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/joomcode/errorx"
-
 	"go.dfds.cloud/aad-aws-sync/internal/azure"
 	"go.dfds.cloud/aad-aws-sync/internal/capsvc"
 	"go.dfds.cloud/aad-aws-sync/internal/config"
@@ -58,7 +57,7 @@ func Capsvc2AadHandler(ctx context.Context) error {
 		return err
 	}
 
-	for _, capability := range capabilities.Items {
+	for _, capability := range capabilities {
 		_, err := capability.GetContext()
 		if err == nil {
 			capabilitiesByRootId[capability.RootID] = capability


### PR DESCRIPTION
- CapSvc client now gets clientid & clientsecret from a different configuration path
- Changed capsvc client to work with selfservice-api instead of capability-service
