### PR TITLE
Feat/retrieve org accounts from provided ou

### DIFF
--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -372,6 +372,26 @@ func GetAllOUsFromParent(ctx context.Context, client *organizations.Client, pare
 	return ou, nil
 }
 
+func GetAllAccountsFromOuRecursive(ctx context.Context, client *organizations.Client, parentId string) ([]orgTypes.Account, error) {
+	orgUnits, err := GetAllOUsFromParent(context.TODO(), client, parentId)
+	if err != nil {
+		return nil, err
+	}
+	orgUnits = append(orgUnits, orgTypes.OrganizationalUnit{Id: &parentId})
+
+	var allAccounts []orgTypes.Account
+
+	for _, ou := range orgUnits {
+		orgUnitAccounts, err := GetAccounts(client, *ou.Id)
+		if err != nil {
+			return nil, err
+		}
+		allAccounts = append(allAccounts, orgUnitAccounts...)
+	}
+
+	return allAccounts, nil
+}
+
 func GetGroups(client *identitystore.Client, identityStoreArn string) ([]identityTypes.Group, error) {
 	var maxResults int32 = 100
 	var payload []identityTypes.Group

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -334,6 +334,7 @@ func GetAccounts(client *organizations.Client, parentId string) ([]orgTypes.Acco
 	for resps.HasMorePages() { // Due to the limit of only 20 accounts per query and wanting to avoid getting hit by a rate limit, this will take a while if you have a decent amount of AWS accounts
 		page, err := resps.NextPage(context.TODO())
 		if err != nil {
+			util.Logger.Sugar().Errorf("Error getting accounts: %v", err)
 			return accounts, err
 		}
 

--- a/internal/aws/sso.go
+++ b/internal/aws/sso.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -129,7 +130,7 @@ func InitManageSso(cfg aws.Config, identityStoreArn string) (*ManageSso, error) 
 	orgClient := organizations.NewFromConfig(cfg)
 	identityStoreClient := identitystore.NewFromConfig(cfg)
 
-	awsAccounts, err := GetAccounts(orgClient, conf.Aws.OrganizationsParentId)
+	awsAccounts, err := GetAllAccountsFromOuRecursive(context.TODO(), orgClient, conf.Aws.RootOrganizationsParentId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/aws/sso.go
+++ b/internal/aws/sso.go
@@ -2,13 +2,15 @@ package aws
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/identitystore"
 	identityStoreTypes "github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	orgTypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
-	"strings"
+	"go.dfds.cloud/aad-aws-sync/internal/config"
 )
 
 type ManageSso struct { // TODO, make sure Account & Group are only allocated once
@@ -112,6 +114,11 @@ func RemoveAccountPrefix(prefix string, val string) string {
 }
 
 func InitManageSso(cfg aws.Config, identityStoreArn string) (*ManageSso, error) {
+	conf, err := config.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	payload := &ManageSso{
 		awsAccountsByAlias: map[string]*orgTypes.Account{},
 		awsAccountsById:    map[string]*orgTypes.Account{},
@@ -122,7 +129,7 @@ func InitManageSso(cfg aws.Config, identityStoreArn string) (*ManageSso, error) 
 	orgClient := organizations.NewFromConfig(cfg)
 	identityStoreClient := identitystore.NewFromConfig(cfg)
 
-	awsAccounts, err := GetAccounts(orgClient)
+	awsAccounts, err := GetAccounts(orgClient, conf.Aws.OrganizationsParentId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,8 @@ type Config struct {
 			Endpoint string `json:"endpoint"`
 			Token    string `json:"token"`
 		}
-		OrganizationsParentId string `json:"organizationsParentId"`
+		OrganizationsParentId     string `json:"organizationsParentId"`
+		RootOrganizationsParentId string `json:"rootOrganizationsParentId"`
 	} `json:"aws"`
 	Azure struct {
 		TenantId            string `json:"tenantId"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 			Endpoint string `json:"endpoint"`
 			Token    string `json:"token"`
 		}
+		OrganizationsParentId string `json:"organizationsParentId"`
 	} `json:"aws"`
 	Azure struct {
 		TenantId            string `json:"tenantId"`

--- a/internal/handler/aws2k8s.go
+++ b/internal/handler/aws2k8s.go
@@ -11,7 +11,6 @@ import (
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
-	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"go.dfds.cloud/aad-aws-sync/internal/aws"
 	"go.dfds.cloud/aad-aws-sync/internal/config"
@@ -61,22 +60,11 @@ func Aws2K8sHandler(ctx context.Context) error {
 	}
 
 	// Get all OU's from parent organization ID
-	orgUnits, err := aws.GetAllOUsFromParent(context.TODO(), orgClient, conf.Aws.OrganizationsParentId)
+	allAccounts, err := aws.GetAllAccountsFromOuRecursive(ctx, orgClient, conf.Aws.OrganizationsParentId)
 	if err != nil {
 		return err
 	}
-
-	// Get all AWS accounts from all OU's
-	var allAccounts []types.Account
-
-	for _, ou := range orgUnits {
-		orgUnitAccounts, err := aws.GetAccounts(orgClient, *ou.Id)
-		if err != nil {
-			return err
-		}
-		allAccounts = append(allAccounts, orgUnitAccounts...)
-	}
-
+	
 	ssoRoleMappings := []aws.SsoRoleMapping{}
 
 	// Put AWS accounts in a useful format

--- a/internal/handler/aws2k8s.go
+++ b/internal/handler/aws2k8s.go
@@ -60,7 +60,7 @@ func Aws2K8sHandler(ctx context.Context) error {
 	}
 
 	// Get all AWS accounts
-	accounts, err := aws.GetAccounts(orgClient)
+	accounts, err := aws.GetAccounts(orgClient, conf.Aws.OrganizationsParentId)
 	if err != nil {
 		return err
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -167,6 +167,7 @@ func (j *Job) Run() {
 		err := j.handler(j.context)
 		if err != nil {
 			jobFailedCount.WithLabelValues(j.Name).Inc()
+			util.Logger.Error("Job failed", zap.String("jobName", j.Name), zap.Error(err))
 		} else {
 			jobSuccessfulCount.WithLabelValues(j.Name).Inc()
 		}


### PR DESCRIPTION
This PR requires you to set an organizational unit id to retrieve AWS Organizations accounts from using the variable:

`AAS_AWS_ORGANIZATIONSPARENTID=""`

There is no default value set. However, if you set the variable to the Organization Account root ID then technically behaviour should not change.